### PR TITLE
change non-top-level function declaration to private variables

### DIFF
--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -43,30 +43,30 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 			trigger: 'hover',
 			updateAnimation: true
 		};
-	
+
 	function Plugin(element, options) {
 		this.element = element;
-		
+
 		this.options = $.extend( {}, defaults, options );
-		
+
 		this._defaults = defaults;
 		this._name = pluginName;
-		
+
 		this.init();
 	}
-	
+
 	// we'll use this to detect for mobile devices
 	function is_touch_device() {
 		return !!('ontouchstart' in window);
   	}
-  	
+
   	// detecting support for CSS transitions
   	function supportsTransitions() {
 	    var b = document.body || document.documentElement;
 	    var s = b.style;
 	    var p = 'transition';
 	    if(typeof s[p] == 'string') {return true; }
-	
+
 	    v = ['Moz', 'Webkit', 'Khtml', 'O', 'ms'],
 	    p = p.charAt(0).toUpperCase() + p.substr(1);
 	    for(var i=0; i<v.length; i++) {
@@ -78,41 +78,41 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
     if (!supportsTransitions()) {
 	    transitionSupport = false;
     }
-    
+
     // detect if this device is mouse driven over purely touch
     var touchDevice = is_touch_device();
-    
+
     // on mousemove, double confirm that this is a desktop - not a touch device
   	$(window).on('mousemove.tooltipster', function() {
-	  	touchDevice = false;	  	
+	  	touchDevice = false;
 	  	$(window).off('mousemove.tooltipster');
   	});
-  	
-  	
-  	
-    	
+
+
+
+
 	Plugin.prototype = {
-		
-		init: function() {		
+
+		init: function() {
 			var $this = $(this.element);
 			var object = this;
 			var run = true;
-			
+
 			// if this is a touch device and touch devices are disabled, disable the plugin
 			if ((object.options.touchDevices == false) && (touchDevice)) {
 				run = false;
 			}
-			
+
 			// if IE7 or lower, disable the plugin
 			if (document.all && !document.querySelector) {
 				run = false;
     		}
-    					
+
 			if (run == true) {
-				
+
 				// detect if we're changing the tooltip origin to an icon
 				if ((this.options.iconDesktop == true) && (!touchDevice) || ((this.options.iconTouch == true) && (touchDevice))) {
-					var transferContent = $this.attr('title');					
+					var transferContent = $this.attr('title');
 					$this.removeAttr('title');
 					var theme = object.options.iconTheme;
 					var icon = $('<span class="'+ theme.replace('.', '') +'" title="'+ transferContent +'">'+ this.options.icon +'</span>');
@@ -120,34 +120,34 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 					$this.data('tooltipsterIcon', icon);
 					$this = icon;
 				}
-			
+
 				// first, strip the title off of the element and set it as a data attribute to prevent the default tooltips from popping up
 				var tooltipsterContent = $.trim(object.options.content).length > 0 ? object.options.content : $this.attr('title');
 				$this.data('tooltipsterContent', tooltipsterContent);
 				$this.removeAttr('title');
-				
+
 				// if this is a touch device, add some touch events to launch the tooltip
 				if ((this.options.touchDevices == true) && (touchDevice) && ((this.options.trigger == 'click') || (this.options.trigger == 'hover'))) {
 					$this.bind('touchstart', function(element, options) {
 						object.showTooltip();
 					});
 				}
-				
+
 				// if this is a desktop, deal with adding regular mouse events
 				else {
-				
+
 					// if hover events are set to show and hide the tooltip, attach those events respectively
 					if (this.options.trigger == 'hover') {
 						$this.on('mouseenter.tooltipster', function() {
 							object.showTooltip();
 						});
-						
+
 						// if this is an interactive tooltip, delay getting rid of the tooltip right away so you have a chance to hover on the tooltip
 						if (this.options.interactive == true) {
 							$this.on('mouseleave.tooltipster', function() {
 								var tooltipster = $this.data('tooltipster');
 								var keepAlive = false;
-								
+
 								if ((tooltipster !== undefined) && (tooltipster !== '')) {
 									tooltipster.mouseenter(function() {
 										keepAlive = true;
@@ -155,7 +155,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 									tooltipster.mouseleave(function() {
 										keepAlive = false;
 									});
-									
+
 									var tolerance = setTimeout(function() {
 										if (keepAlive == true) {
 											tooltipster.mouseleave(function() {
@@ -172,7 +172,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 								}
 							});
 						}
-						
+
 						// if this is a dumb tooltip, just get rid of it on mouseleave
 						else {
 							$this.on('mouseleave.tooltipster', function() {
@@ -180,7 +180,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 							});
 						}
 					}
-					
+
 					// if click events are set to show and hide the tooltip, attach those events respectively
 					if (this.options.trigger == 'click') {
 						$this.on('click.tooltipster', function() {
@@ -195,19 +195,19 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 				}
 			}
 		},
-		
-		showTooltip: function(options) {			
+
+		showTooltip: function(options) {
 			var $this = $(this.element);
 			var object = this;
-						
+
 			// detect if we're actually dealing with an icon or the origin itself
 			if ($this.data('tooltipsterIcon') !== undefined) {
 				$this = $this.data('tooltipsterIcon');
 			}
-			
+
 			// continue if this tooltip is enabled
 			if (!$this.hasClass('tooltipster-disable')) {
-			
+
 				// if we only want one tooltip open at a time, close all tooltips currently open
 				if (($('.tooltipster-base').not('.tooltipster-dying').length > 0) && (object.options.onlyOne == true)) {
 					$('.tooltipster-base').not('.tooltipster-dying').not($this.data('tooltipster')).each(function() {
@@ -216,53 +216,53 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 						origin.data('plugin_tooltipster').hideTooltip();
 					});
 				}
-						
+
 				// delay the showing of the tooltip according to the delay time
 				$this.clearQueue().delay(object.options.delay).queue(function() {
-				
+
 					// call our custom function before continuing
 					object.options.functionBefore($this, function() {
-						
+
 						// if this origin already has its tooltip open, keep it open and do nothing else
 						if (($this.data('tooltipster') !== undefined) && ($this.data('tooltipster') !== '')) {
 							var tooltipster = $this.data('tooltipster');
-							
+
 							if (!tooltipster.hasClass('tooltipster-kill')) {
-	
+
 								var animation = 'tooltipster-'+ object.options.animation;
-								
+
 								tooltipster.removeClass('tooltipster-dying');
-								
+
 								if (transitionSupport == true) {
 									tooltipster.clearQueue().addClass(animation +'-show');
 								}
-								
+
 								// if we have a timer set, we need to reset it
 								if (object.options.timer > 0) {
 									var timer = tooltipster.data('tooltipsterTimer');
 									clearTimeout(timer);
-														
+
 									timer = setTimeout(function() {
 										tooltipster.data('tooltipsterTimer', undefined);
 										object.hideTooltip();
 									}, object.options.timer);
-									
+
 									tooltipster.data('tooltipsterTimer', timer);
 								}
-								
+
 								// if this is a touch device, hide the tooltip on body touch
 								if ((object.options.touchDevices == true) && (touchDevice)) {
 									$('body').bind('touchstart', function(event) {
 										if (object.options.interactive == true) {
 											var touchTarget = $(event.target);
 											var closeTooltip = true;
-											
+
 											touchTarget.parents().each(function() {
 												if ($(this).hasClass('tooltipster-base')) {
 													closeTooltip = false;
 												}
 											});
-											
+
 											if (closeTooltip == true) {
 												object.hideTooltip();
 												$('body').unbind('touchstart');
@@ -276,15 +276,15 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 								}
 							}
 						}
-						
+
 						// if the tooltip isn't already open, open that sucker up!
 						else {
 							// disable horizontal scrollbar to keep overflowing tooltips from jacking with it
 							$('body').css('overflow-x', 'hidden');
-							
+
 							// get the content for the tooltip
 							var content = $this.data('tooltipsterContent');
-							
+
 							// get some other settings related to building the tooltip
 							var theme = object.options.theme;
 							var themeClass = theme.replace('.', '');
@@ -293,26 +293,26 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 							var fixedWidth = object.options.fixedWidth > 0 ? 'width:'+ object.options.fixedWidth +'px;' : '';
 							var maxWidth = object.options.maxWidth > 0 ? 'max-width:'+ object.options.maxWidth +'px;' : '';
 							var pointerEvents = object.options.interactive == true ? 'pointer-events: auto;' : '';
-												
+
 							// build the base of our tooltip
 							var tooltipster = $('<div class="tooltipster-base '+ themeClass +' '+ animation +'" style="'+ fixedWidth +' '+ maxWidth +' '+ pointerEvents +' '+ animationSpeed +'"></div>');
 							var tooltipsterHTML = $('<div class="tooltipster-content"></div>');
 							tooltipsterHTML.html(content);
 							tooltipster.append(tooltipsterHTML);
-							
-							
+
+
 							tooltipster.appendTo('body');
-							
+
 							// attach the tooltip to its origin
 							$this.data('tooltipster', tooltipster);
 							tooltipster.data('origin', $this);
-							
+
 							// do all the crazy calculations and positioning
 							object.positionTooltip();
-							
+
 							// call our custom callback since the content of the tooltip is now part of the DOM
 							object.options.functionReady($this, tooltipster);
-							
+
 							// animate in the tooltip
 							if (transitionSupport == true) {
 								tooltipster.addClass(animation + '-show');
@@ -320,25 +320,25 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 							else {
 								tooltipster.css('display', 'none').removeClass(animation).fadeIn(object.options.speed);
 							}
-							
+
 							// check to see if our tooltip content changes or its origin is removed while the tooltip is alive
 							var currentTooltipContent = content;
-							var contentUpdateChecker = setInterval(function() {		
+							var contentUpdateChecker = setInterval(function() {
 								var newTooltipContent = $this.data('tooltipsterContent');
-								
+
 								// if this tooltip's origin is removed, remove the tooltip
 								if ($('body').find($this).length == 0) {
 									tooltipster.addClass('tooltipster-dying');
 									object.hideTooltip();
 								}
-								
-								// if the content changed for the tooltip, update it											
+
+								// if the content changed for the tooltip, update it
 								else if ((currentTooltipContent !== newTooltipContent) && (newTooltipContent !== '')) {
 									currentTooltipContent = newTooltipContent;
-									
+
 									// set the new content in the tooltip
 									tooltipster.find('.tooltipster-content').html(newTooltipContent);
-									
+
 									// if we want to play a little animation showing the content changed
 									if (object.options.updateAnimation == true) {
 										if (supportsTransitions()) {
@@ -350,7 +350,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 												'-ms-transition': 'all ' + object.options.speed + 'ms, width 0ms, height 0ms, left 0ms, top 0ms',
 												'transition': 'all ' + object.options.speed + 'ms, width 0ms, height 0ms, left 0ms, top 0ms'
 											}).addClass('tooltipster-content-changing');
-											
+
 											// reset the CSS transitions and finish the change animation
 											setTimeout(function() {
 												tooltipster.removeClass('tooltipster-content-changing');
@@ -372,41 +372,41 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 											});
 										}
 									}
-									
+
 									// reposition and resize the tooltip
 									object.positionTooltip();
 								}
-								
+
 								// if the tooltip is closed or origin is removed, clear this interval
 								if (($('body').find(tooltipster).length == 0) || ($('body').find($this).length == 0)) {
 									clearInterval(contentUpdateChecker);
 								}
 							}, 200);
-							
+
 							// if we have a timer set, let the countdown begin!
-							if (object.options.timer > 0) {							
+							if (object.options.timer > 0) {
 								var timer = setTimeout(function() {
 									tooltipster.data('tooltipsterTimer', undefined);
 									object.hideTooltip();
 								}, object.options.timer + object.options.speed);
-								
+
 								tooltipster.data('tooltipsterTimer', timer);
 							}
-							
+
 							// if this is a touch device, hide the tooltip on body touch
 							if ((object.options.touchDevices == true) && (touchDevice)) {
 								$('body').bind('touchstart', function(event) {
 									if (object.options.interactive == true) {
-										
+
 										var touchTarget = $(event.target);
 										var closeTooltip = true;
-																			
+
 										touchTarget.parents().each(function() {
 											if ($(this).hasClass('tooltipster-base')) {
 												closeTooltip = false;
 											}
 										});
-										
+
 										if (closeTooltip == true) {
 											object.hideTooltip();
 											$('body').unbind('touchstart');
@@ -418,41 +418,41 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 									}
 								});
 							}
-							
+
 							// if this is an interactive tooltip activated by a click, close the tooltip when you hover off the tooltip
 							tooltipster.mouseleave(function() {
 								object.hideTooltip();
 							});
 						}
 					});
-					
+
 					$this.dequeue();
 				});
 			}
 		},
-		
+
 		hideTooltip: function(options) {
-						
+
 			var $this = $(this.element);
 			var object = this;
-			
+
 			// detect if we're actually dealing with an icon or the origin itself
 			if ($this.data('tooltipsterIcon') !== undefined) {
 				$this = $this.data('tooltipsterIcon');
 			}
-			
+
 			var tooltipster = $this.data('tooltipster');
-			
+
 			// if the origin has been removed, find all tooltips assigned to death
 			if (tooltipster == undefined) {
 				tooltipster = $('.tooltipster-dying');
 			}
-			
+
 			// clear any possible queues handling delays and such
 			$this.clearQueue();
-			
+
 			if ((tooltipster !== undefined) && (tooltipster !== '')) {
-				
+
 				// detect if we need to clear a timer
 				var timer = tooltipster.data('tooltipsterTimer');
 				if (timer !== undefined) {
@@ -460,13 +460,13 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 				}
 
 				var animation = 'tooltipster-'+ object.options.animation;
-				
+
 				if (transitionSupport == true) {
 					tooltipster.clearQueue().removeClass(animation +'-show').addClass('tooltipster-dying').delay(object.options.speed).queue(function() {
 						tooltipster.remove();
 						$this.data('tooltipster', '');
 						$('body').css('verflow-x', '');
-						
+
 						// finally, call our custom callback function
 						object.options.functionAfter($this);
 					});
@@ -476,30 +476,30 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 						tooltipster.remove();
 						$this.data('tooltipster', '');
 						$('body').css('verflow-x', '');
-						
+
 						// finally, call our custom callback function
 						object.options.functionAfter($this);
 					});
 				}
 			}
 		},
-		
+
 		positionTooltip: function(options) {
-					
+
 			var $this = $(this.element);
 			var object = this;
-									
+
 			// detect if we're actually dealing with an icon or the origin itself
 			if ($this.data('tooltipsterIcon') !== undefined) {
 				$this = $this.data('tooltipsterIcon');
 			}
-			
+
 			if (($this.data('tooltipster') !== undefined) && ($this.data('tooltipster') !== '')) {
-						
+
 				// find tooltipster and reset its width
 				var tooltipster = $this.data('tooltipster');
 				tooltipster.css('width', '');
-				
+
 				// find variables to determine placement
 				var windowWidth = $(window).width();
 				var containerWidth = $this.outerWidth(false);
@@ -511,7 +511,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 				var offsetTop = offset.top;
 				var offsetLeft = offset.left;
 				var resetPosition = undefined;
-				
+
 				// if this is an <area> tag inside a <map>, all hell breaks loose. Recaclulate all the measurements based on coordinates
 				if ($this.is('area')) {
 					var areaShape = $this.attr('shape');
@@ -520,7 +520,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 					var mapOffsetLeft = map.offset().left;
 					var mapOffsetTop = map.offset().top;
 					var areaMeasurements = $this.attr('coords') !== undefined ? $this.attr('coords').split(',') : undefined;
-					
+
 					if (areaShape == 'circle') {
 						var areaLeft = parseInt(areaMeasurements[0]);
 						var areaTop = parseInt(areaMeasurements[1]);
@@ -548,10 +548,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 							areaGreatestX = 0,
 							areaGreatestY = 0;
 						var arrayAlternate = 'even';
-						
+
 						for (i = 0; i < areaMeasurements.length; i++) {
 							var areaNumber = parseInt(areaMeasurements[i]);
-							
+
 							if (arrayAlternate == 'even') {
 								if (areaNumber > areaGreatestX) {
 									areaGreatestX = areaNumber;
@@ -559,11 +559,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 										areaSmallestX = areaGreatestX;
 									}
 								}
-								
+
 								if (areaNumber < areaSmallestX) {
 									areaSmallestX = areaNumber;
 								}
-								
+
 								arrayAlternate = 'odd';
 							}
 							else {
@@ -573,15 +573,15 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 										areaSmallestY = areaGreatestY;
 									}
 								}
-								
+
 								if (areaNumber < areaSmallestY) {
 									areaSmallestY = areaNumber;
 								}
-								
+
 								arrayAlternate = 'even';
 							}
 						}
-					
+
 						containerHeight = areaGreatestY - areaSmallestY;
 						containerWidth = areaGreatestX - areaSmallestX;
 						offsetTop = mapOffsetTop + areaSmallestY;
@@ -594,7 +594,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 						offsetLeft = mapOffsetLeft;
 					}
 				}
-																
+
 				// hardcoding the width and removing the padding fixed an issue with the tooltip width collapsing when the window size is small
 				if(object.options.fixedWidth == 0) {
 					tooltipster.css({
@@ -603,44 +603,44 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 						'padding-right': '0px'
 					});
 				}
-				
+
 				// our function and global vars for positioning our tooltip
 				var myLeft = 0,
 					myTop = 0;
 				var offsetY = parseInt(object.options.offsetY);
 				var offsetX = parseInt(object.options.offsetX);
 				var arrowConstruct = '';
-				
+
 				// A function to detect if the tooltip is going off the screen horizontally. If so, reposition the crap out of it!
-				function dontGoOffScreenX() {
-				
+				var dontGoOffScreenX = function() {
+
 					var windowLeft = $(window).scrollLeft();
-					
+
 					// If the tooltip goes off the left side of the screen, line it up with the left side of the window
 					if((myLeft - windowLeft) < 0) {
 						var arrowReposition = myLeft - windowLeft;
 						myLeft = windowLeft;
-																								
+
 						tooltipster.data('arrow-reposition', arrowReposition);
 					}
-					
+
 					// If the tooltip goes off the right of the screen, line it up with the right side of the window
 					if (((myLeft + tooltipWidth) - windowLeft) > windowWidth) {
 						var arrowReposition = myLeft - ((windowWidth + windowLeft) - tooltipWidth);
 						myLeft = (windowWidth + windowLeft) - tooltipWidth;
-																												
+
 						tooltipster.data('arrow-reposition', arrowReposition);
 					}
 				}
-				
+
 				// A function to detect if the tooltip is going off the screen vertically. If so, switch to the opposite!
-				function dontGoOffScreenY(switchTo, resetTo) {
+				var dontGoOffScreenY = function(switchTo, resetTo) {
 					// if it goes off the top off the page
 					if(((offsetTop - $(window).scrollTop() - tooltipHeight - offsetY - 12) < 0) && (resetTo.indexOf('top') > -1)) {
 						object.options.position = switchTo;
 						resetPosition = resetTo;
 					}
-					
+
 					// if it goes off the bottom of the page
 					if (((offsetTop + containerHeight + tooltipHeight + 12 + offsetY) > ($(window).scrollTop() + $(window).height())) && (resetTo.indexOf('bottom') > -1)) {
 						object.options.position = switchTo;
@@ -648,7 +648,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 						myTop = (offsetTop - tooltipHeight) - offsetY - 12;
 					}
 				}
-							
+
 				if(object.options.position == 'top') {
 					var leftDifference = (offsetLeft + tooltipWidth) - (offsetLeft + containerWidth);
 					myLeft =  (offsetLeft + offsetX) - (leftDifference / 2);
@@ -656,21 +656,21 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 					dontGoOffScreenX();
 					dontGoOffScreenY('bottom', 'top');
 				}
-				
+
 				if(object.options.position == 'top-left') {
 					myLeft = offsetLeft + offsetX;
 					myTop = (offsetTop - tooltipHeight) - offsetY - 12;
 					dontGoOffScreenX();
 					dontGoOffScreenY('bottom-left', 'top-left');
 				}
-				
+
 				if(object.options.position == 'top-right') {
 					myLeft = (offsetLeft + containerWidth + offsetX) - tooltipWidth;
 					myTop = (offsetTop - tooltipHeight) - offsetY - 12;
 					dontGoOffScreenX();
 					dontGoOffScreenY('bottom-right', 'top-right');
 				}
-				
+
 				if(object.options.position == 'bottom') {
 					var leftDifference = (offsetLeft + tooltipWidth) - (offsetLeft + containerWidth);
 					myLeft =  offsetLeft - (leftDifference / 2) + offsetX;
@@ -678,76 +678,76 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 					dontGoOffScreenX();
 					dontGoOffScreenY('top', 'bottom');
 				}
-				
+
 				if(object.options.position == 'bottom-left') {
 					myLeft = offsetLeft + offsetX;
 					myTop = (offsetTop + containerHeight) + offsetY + 12;
 					dontGoOffScreenX();
 					dontGoOffScreenY('top-left', 'bottom-left');
 				}
-				
+
 				if(object.options.position == 'bottom-right') {
 					myLeft = (offsetLeft + containerWidth + offsetX) - tooltipWidth;
 					myTop = (offsetTop + containerHeight) + offsetY + 12;
 					dontGoOffScreenX();
 					dontGoOffScreenY('top-right', 'bottom-right');
 				}
-				
+
 				if(object.options.position == 'left') {
 					myLeft = offsetLeft - offsetX - tooltipWidth - 12;
 					myLeftMirror = offsetLeft + offsetX + containerWidth + 12;
 					var topDifference = (offsetTop + tooltipHeight) - (offsetTop + $this.outerHeight(false));
 					myTop =  offsetTop - (topDifference / 2) - offsetY;
-												
+
 					// If the tooltip goes off boths sides of the page
 					if((myLeft < 0) && ((myLeftMirror + tooltipWidth) > windowWidth)) {
 						var borderWidth = parseFloat(tooltipster.css('border-width')) * 2;
 						var newWidth = (tooltipWidth + myLeft) - borderWidth;
 						tooltipster.css('width', newWidth + 'px');
-						
+
 						tooltipHeight = tooltipster.outerHeight(false);
 						myLeft = offsetLeft - offsetX - newWidth - 12 - borderWidth;
 						topDifference = (offsetTop + tooltipHeight) - (offsetTop + $this.outerHeight(false));
 						myTop =  offsetTop - (topDifference / 2) - offsetY;
 					}
-					
+
 					// If it only goes off one side, flip it to the other side
 					else if(myLeft < 0) {
 						myLeft = offsetLeft + offsetX + containerWidth + 12;
 						tooltipster.data('arrow-reposition', 'left');
 					}
 				}
-				
+
 				if(object.options.position == 'right') {
 					myLeft = offsetLeft + offsetX + containerWidth + 12;
 					myLeftMirror = offsetLeft - offsetX - tooltipWidth - 12;
 					var topDifference = (offsetTop + tooltipHeight) - (offsetTop + $this.outerHeight(false));
 					myTop =  offsetTop - (topDifference / 2) - offsetY;
-					
+
 					// If the tooltip goes off boths sides of the page
 					if(((myLeft + tooltipWidth) > windowWidth) && (myLeftMirror < 0)) {
 						var borderWidth = parseFloat(tooltipster.css('border-width')) * 2;
 						var newWidth = (windowWidth - myLeft) - borderWidth;
 						tooltipster.css('width', newWidth + 'px');
-						
+
 						tooltipHeight = tooltipster.outerHeight(false);
 						topDifference = (offsetTop + tooltipHeight) - (offsetTop + $this.outerHeight(false));
 						myTop =  offsetTop - (topDifference / 2) - offsetY;
-	
+
 					}
-						
+
 					// If it only goes off one side, flip it to the other side
 					else if((myLeft + tooltipWidth) > windowWidth) {
 						myLeft = offsetLeft - offsetX - tooltipWidth - 12;
 						tooltipster.data('arrow-reposition', 'right');
 					}
 				}
-				
+
 				// if arrow is set true, style it and append it
 				if (object.options.arrow == true) {
-	
+
 					var arrowClass = 'tooltipster-arrow-' + object.options.position;
-					
+
 					// set color of the arrow
 					if(object.options.arrowColor.length < 1) {
 						var arrowColor = tooltipster.css('background-color');
@@ -755,7 +755,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 					else {
 						var arrowColor = object.options.arrowColor;
 					}
-					
+
 					// if the tooltip was going off the page and had to re-adjust, we need to update the arrow's position
 					var arrowReposition = tooltipster.data('arrow-reposition');
 					if (!arrowReposition) {
@@ -772,7 +772,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 					else {
 						arrowReposition = 'left:'+ arrowReposition +'px;';
 					}
-										
+
 					// building the logic to create the border around the arrow of the tooltip
 					if ((object.options.position == 'top') || (object.options.position == 'top-left') || (object.options.position == 'top-right')) {
 						var tooltipBorderWidth = parseFloat(tooltipster.css('border-bottom-width'));
@@ -794,11 +794,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 						var tooltipBorderWidth = parseFloat(tooltipster.css('border-bottom-width'));
 						var tooltipBorderColor = tooltipster.css('border-bottom-color');
 					}
-					
+
 					if (tooltipBorderWidth > 1) {
 						tooltipBorderWidth++;
 					}
-					
+
 					var arrowBorder = '';
 					if (tooltipBorderWidth !== 0) {
 						var arrowBorderSize = '';
@@ -817,18 +817,18 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 						}
 						arrowBorder = '<span class="tooltipster-arrow-border" style="'+ arrowBorderSize +' '+ arrowBorderColor +';"></span>';
 					}
-					
+
 					// if the arrow already exists, remove and replace it
 					tooltipster.find('.tooltipster-arrow').remove();
-					
-					// build out the arrow and append it		
+
+					// build out the arrow and append it
 					arrowConstruct = '<div class="'+ arrowClass +' tooltipster-arrow" style="'+ arrowReposition +'">'+ arrowBorder +'<span style="border-color:'+ arrowColor +';"></span></div>';
 					tooltipster.append(arrowConstruct);
 				}
-				
+
 				// position the tooltip
 				tooltipster.css({'top': myTop+'px', 'left': myLeft+'px'});
-				
+
 				// if we had to change the position of the tooltip so it wouldn't go off screen, reset it
 				if (resetPosition !== undefined) {
 					object.options.position = resetPosition;
@@ -836,13 +836,13 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 			}
 		}
 	};
-		
+
 	$.fn[pluginName] = function (options) {
 		// better API name spacing by glebtv
 		if (typeof options === 'string') {
 			var $t = this;
 			var newContent = arguments[1];
-			
+
 			// if we're calling a container to interact with API's of tooltips inside it - select all those tooltip origins first
 			if ($t.data('plugin_tooltipster') == undefined) {
 				var query = $t.find('*');
@@ -853,66 +853,66 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 					}
 				});
 			}
-			
+
 			$t.each(function() {
 				switch (options.toLowerCase()) {
 					case 'show':
 						$(this).data('plugin_tooltipster').showTooltip();
 						break;
-	
+
 					case 'hide':
 						$(this).data('plugin_tooltipster').hideTooltip();
 						break;
-					
+
 					case 'disable':
 						$(this).addClass('tooltipster-disable');
 						break;
-					
+
 					case 'enable':
 						$(this).removeClass('tooltipster-disable');
 						break;
-	
+
 					case 'destroy':
 						$(this).data('plugin_tooltipster').hideTooltip();
 						$(this).data('plugin_tooltipster', '').attr('title', $t.data('tooltipsterContent')).data('tooltipsterContent', '').data('plugin_tooltipster', '').off('mouseenter.tooltipster mouseleave.tooltipster click.tooltipster');
 						break;
-	
-					case 'update':						
+
+					case 'update':
 						if ($(this).data('tooltipsterIcon') == undefined) {
 							$(this).data('tooltipsterContent', newContent);
 						}
-						
+
 						else {
 							var $this = $(this).data('tooltipsterIcon');
 							$this.data('tooltipsterContent', newContent);
 						}
-						
+
 						break;
-						
+
 					case 'reposition':
 						$(this).data('plugin_tooltipster').positionTooltip();
 						break;
 				}
 			});
-			
-			return this;			
+
+			return this;
 		}
-		
+
 		// attach a tooltipster object to each element if it doesn't already have one
 		return this.each(function () {
 			if (!$.data(this, "plugin_" + pluginName)) {
 				$.data(this, "plugin_" + pluginName, new Plugin( this, options ));
 			}
-			
+
 			var thisOptions = $(this).data('plugin_tooltipster').options;
-				
+
 			if ((thisOptions.iconDesktop == true) && (!touchDevice) || ((thisOptions.iconTouch == true) && (touchDevice))) {
 				var transferObject = $(this).data('plugin_tooltipster');
 				$(this).next().data('plugin_tooltipster', transferObject);
-			}	
+			}
 		});
 	};
-	
+
 	// hide tooltips on orientation change
 	if (touchDevice) {
 		window.addEventListener("orientationchange", function() {
@@ -924,15 +924,15 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 			}
 	  	}, false);
   	}
-  	
+
   	// on window resize, reposition and open tooltips
   	$(window).on('resize.tooltipster', function() {
 	  	var origin = $('.tooltipster-base').data('origin');
-	  		  	
+
 	  	if ((origin !== null) && (origin !== undefined)) {
 	  		origin.tooltipster('reposition');
 	  	}
   	});
-  	
+
 
 })( jQuery, window, document );


### PR DESCRIPTION
- ES5 strict mode dictates that function statements not at top level of a program or function are prohibited
- declare local variable functions instead of using standard function() blocks for dontGoOffScreenX and dontGoOffScreenY
