### PR TITLE
Distribution via Bower package manager

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,8 @@
+{
+  "name": "tooltipster",
+  "version": "2.1.4",
+  "main": ["js/jquery.tooltipster.min.js", "css/tooltipster.css"],
+  "dependencies": {
+    "jquery": ">=1.4"
+  }
+}


### PR DESCRIPTION
This pull requests adds bower.json, meta file for [Bower](http://bower.io), to the repository. This allows installing and managing the plugin via Bower's CLI, making it even easier to adopt to your project if you are already using Bower.

After the meta file is added to the repository, the project can be registered to Bower's central repository (i.e. index of projects), allowing users to reference the project using a short package name instead of the repository path (e.g. `$ bower install iamceege/tooltipster` becomes `$ bower install tooltipster`). Registering is recommended, but optional. It requires just single command:

```
$ bower register tooltipster git://github.com/iamceege/tooltipster.git
```

Outside from version bumping (as with the plugin meta file), Bower otherwise doesn't cause changes to your existing workflow. It's add and forget type of deal. When you tag a new release, as with the plugin meta, the version field must be bumped in bower.json as well.
