### PR TITLE
Bug fixed: Unbind touch event when destroying the tooltip

### DIFF
--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -874,7 +874,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 	
 					case 'destroy':
 						$(this).data('plugin_tooltipster').hideTooltip();
-						$(this).data('plugin_tooltipster', '').attr('title', $t.data('tooltipsterContent')).data('tooltipsterContent', '').data('plugin_tooltipster', '').off('mouseenter.tooltipster mouseleave.tooltipster click.tooltipster');
+						$(this).data('plugin_tooltipster', '').attr('title', $t.data('tooltipsterContent')).data('tooltipsterContent', '').data('plugin_tooltipster', '').off('mouseenter.tooltipster mouseleave.tooltipster click.tooltipster').unbind('touchstart');
 						break;
 	
 					case 'update':						


### PR DESCRIPTION
Fixed touch event bug.

When tooltip is destroyed the touch event was not removed.
Added unbind to touch event to clear it,

The bind is done here:
// if this is a touch device, add some touch events to launch the tooltip
if ((this.options.touchDevices == true) ...) {
    $this.bind('touchstart', function(element, options) {
        object.showTooltip();
    });
}
