### PR TITLE
Fix XSS on tooltip content insert with <script> tags

### DIFF
--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -283,7 +283,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 							$('body').css('overflow-x', 'hidden');
 							
 							// get the content for the tooltip
-							var content = $this.data('tooltipsterContent');
+							var content = object.getContent($this);
 							
 							// get some other settings related to building the tooltip
 							var theme = object.options.theme;
@@ -324,7 +324,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 							// check to see if our tooltip content changes or its origin is removed while the tooltip is alive
 							var currentTooltipContent = content;
 							var contentUpdateChecker = setInterval(function() {		
-								var newTooltipContent = $this.data('tooltipsterContent');
+								var newTooltipContent = object.getContent($this);
 								
 								// if this tooltip's origin is removed, remove the tooltip
 								if ($('body').find($this).length == 0) {
@@ -335,7 +335,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 								// if the content changed for the tooltip, update it											
 								else if ((currentTooltipContent !== newTooltipContent) && (newTooltipContent !== '')) {
 									currentTooltipContent = newTooltipContent;
-									
+
 									// set the new content in the tooltip
 									tooltipster.find('.tooltipster-content').html(newTooltipContent);
 									
@@ -483,9 +483,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 				}
 			}
 		},
-		
+
 		positionTooltip: function(options) {
-					
+
 			var $this = $(this.element);
 			var object = this;
 									
@@ -834,7 +834,14 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 					object.options.position = resetPosition;
 				}
 			}
-		}
+		},
+    getContent: function(element) {
+      var content = element.data('tooltipsterContent');
+      // will remove <script> tags to prevent XSS (execution of JS for dynamic tooltips)
+      content = $($.parseHTML('<div>' + content + '</div>')).html();
+
+      return content;
+    }
 	};
 		
 	$.fn[pluginName] = function (options) {


### PR DESCRIPTION
If _title_ attribute will have &lt;script&gt; tags in it or we will send 'content' parameter with some text that has &lt;script&gt; tags they will be executed on show. It's not good because the content may be dynamic (depends on site's user edits).

I have added **getContent** method that is the only point to get tooltip's title. It makes all filtrations. Later we can add some option to escape tooltip content (disallow HTML) using this method.

P.S. Sorry for so much commits. I'm noob in git :).
