### PR TITLE
Added an init callback function in options

### DIFF
--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -21,6 +21,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 			delay: 200,
 			fixedWidth: 0,
 			maxWidth: 0,
+			functionInit: function(origin, content) {},
 			functionBefore: function(origin, continueTooltip) {
 				continueTooltip();
 			},
@@ -123,6 +124,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 			
 				// first, strip the title off of the element and set it as a data attribute to prevent the default tooltips from popping up
 				var tooltipsterContent = $.trim(object.options.content).length > 0 ? object.options.content : $this.attr('title');
+				
+				// call our custom init function and replace the value of tooltipsterContent if the function returns something
+				var t = this.options.functionInit($this, tooltipsterContent);
+				if(t) tooltipsterContent = t;
+				
 				$this.data('tooltipsterContent', tooltipsterContent);
 				$this.removeAttr('title');
 				


### PR DESCRIPTION
Added a callback function in the options, called when the tooltip is initialized.

This function receives two parameters : the ORIGIN and the CONTENT which is about to be used for the tooltip. If the function returns something, this result will overwrite CONTENT. This behaviour is handy because the .tooltipster('update', data) method does not work yet at init time.

The main purpose of this is to allow a change on-the-fly from the original Title attribute to the content that will be inserted into the tooltip. It often makes sense to do this change _only once_ at initialization and not everytime the tooltip appears (with functionBefore). It may also be used to load stuff once via Ajax as soon as a tooltip is initialized, etc.
