### PR TITLE
Fixed val method to consider only first matched element

### DIFF
--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -909,7 +909,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 						case 'val':
 							v = $(this).data('tooltipsterContent');
-							break;
+							//return false to stop .each iteration on the first element matched by the selector. No need for a 'break;' after that.
+							return false;
 					}
 				});
 				


### PR DESCRIPTION
Added a "return false" in the 'val' method to stop the .each iteration.
This makes sure that the method returns the value of the first tooltip matched by the selector, not of the last one.
