### PR TITLE
changed functionInit behavior

### DIFF
--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -21,9 +21,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 			delay: 200,
 			fixedWidth: 0,
 			maxWidth: 0,
-			functionInit: function(origin, continueInit) {
-				continueInit();
-			},
+			functionInit: function(origin, content) {},
 			functionBefore: function(origin, continueTooltip) {
 				continueTooltip();
 			},
@@ -113,106 +111,107 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 				// first, strip the title off of the element and set it as a data attribute to prevent the default tooltips from popping up
 				var tooltipsterContent = $.trim(object.options.content).length > 0 ? object.options.content : $this.attr('title');
 				
+				var c = object.options.functionInit($this, tooltipsterContent);
+				if(c) tooltipsterContent = c;
+				
 				$this.data('tooltipsterContent', tooltipsterContent);
 				$this.removeAttr('title');
 
-				object.options.functionInit($this, function() {
-					// detect if we're changing the tooltip origin to an icon
-					if ((object.options.iconDesktop) && (!touchDevice) || ((object.options.iconTouch) && (touchDevice))) {
-						var transferContent = $this.attr('title');
-						$this.removeAttr('title');
-						var theme = object.options.iconTheme;
-						var icon = $('<span class="'+ theme.replace('.', '') +'" title="'+ transferContent +'">'+ object.options.icon +'</span>');
-						icon.insertAfter($this);
-						$this.data('tooltipsterIcon', icon);
-						$this = icon;
-					}
-					
-					// if this is a touch device, add some touch events to launch the tooltip
-					if ((object.options.touchDevices) && (touchDevice) && ((object.options.trigger == 'click') || (object.options.trigger == 'hover'))) {
-						$this.bind('touchstart', function(element, options) {
+				// detect if we're changing the tooltip origin to an icon
+				if ((object.options.iconDesktop) && (!touchDevice) || ((object.options.iconTouch) && (touchDevice))) {
+					var transferContent = $this.attr('title');
+					$this.removeAttr('title');
+					var theme = object.options.iconTheme;
+					var icon = $('<span class="'+ theme.replace('.', '') +'" title="'+ transferContent +'">'+ object.options.icon +'</span>');
+					icon.insertAfter($this);
+					$this.data('tooltipsterIcon', icon);
+					$this = icon;
+				}
+				
+				// if this is a touch device, add some touch events to launch the tooltip
+				if ((object.options.touchDevices) && (touchDevice) && ((object.options.trigger == 'click') || (object.options.trigger == 'hover'))) {
+					$this.bind('touchstart', function(element, options) {
+						object.showTooltip();
+					});
+				}
+				
+				// if this is a desktop, deal with adding regular mouse events
+				else {
+				
+					// if hover events are set to show and hide the tooltip, attach those events respectively
+					if (object.options.trigger == 'hover') {
+						$this.on('mouseenter.tooltipster', function() {
 							object.showTooltip();
 						});
-					}
-					
-					// if this is a desktop, deal with adding regular mouse events
-					else {
-					
-						// if hover events are set to show and hide the tooltip, attach those events respectively
-						if (object.options.trigger == 'hover') {
-							$this.on('mouseenter.tooltipster', function() {
-								object.showTooltip();
-							});
-							
-							// if this is an interactive tooltip, delay getting rid of the tooltip right away so you have a chance to hover on the tooltip
-							if (object.options.interactive) {
-								$this.on('mouseleave.tooltipster', function() {
-									var tooltipster = $this.data('tooltipster');
-									var keepAlive = false;
-									
-									if ((tooltipster !== undefined) && (tooltipster !== '')) {
-										tooltipster.mouseenter(function() {
-											keepAlive = true;
-										});
-										tooltipster.mouseleave(function() {
-											keepAlive = false;
-										});
-										
-										var tolerance = setTimeout(function() {
-
-											if (keepAlive) {
-												if (object.options.interactiveAutoClose) {
-													tooltipster.find('select').on('change', function() {
-														object.hideTooltip();
-													});
-
-													tooltipster.mouseleave(function(e) {
-														var $target = $(e.target);
-
-														if ($target.parents('.tooltipster-base').length === 0 || $target.hasClass('tooltipster-base')) {
-															object.hideTooltip();
-														}
-
-														else {
-															$target.on('mouseleave', function(e) {
-																object.hideTooltip();
-															});
-														}
-													});
-												}
-											}
-											else {
-												object.hideTooltip();
-											}
-										}, object.options.interactiveTolerance);
-									}
-									else {
-										object.hideTooltip();
-									}
-								});
-							}
-							
-							// if this is a dumb tooltip, just get rid of it on mouseleave
-							else {
-								$this.on('mouseleave.tooltipster', function() {
-									object.hideTooltip();
-								});
-							}
-						}
 						
-						// if click events are set to show and hide the tooltip, attach those events respectively
-						if (object.options.trigger == 'click') {
-							$this.on('click.tooltipster', function() {
-								if (($this.data('tooltipster') === '') || ($this.data('tooltipster') === undefined)) {
-									object.showTooltip();
+						// if this is an interactive tooltip, delay getting rid of the tooltip right away so you have a chance to hover on the tooltip
+						if (object.options.interactive) {
+							$this.on('mouseleave.tooltipster', function() {
+								var tooltipster = $this.data('tooltipster');
+								var keepAlive = false;
+								
+								if ((tooltipster !== undefined) && (tooltipster !== '')) {
+									tooltipster.mouseenter(function() {
+										keepAlive = true;
+									});
+									tooltipster.mouseleave(function() {
+										keepAlive = false;
+									});
+									
+									var tolerance = setTimeout(function() {
+
+										if (keepAlive) {
+											if (object.options.interactiveAutoClose) {
+												tooltipster.find('select').on('change', function() {
+													object.hideTooltip();
+												});
+
+												tooltipster.mouseleave(function(e) {
+													var $target = $(e.target);
+
+													if ($target.parents('.tooltipster-base').length === 0 || $target.hasClass('tooltipster-base')) {
+														object.hideTooltip();
+													}
+
+													else {
+														$target.on('mouseleave', function(e) {
+															object.hideTooltip();
+														});
+													}
+												});
+											}
+										}
+										else {
+											object.hideTooltip();
+										}
+									}, object.options.interactiveTolerance);
 								}
 								else {
 									object.hideTooltip();
 								}
 							});
 						}
+						
+						// if this is a dumb tooltip, just get rid of it on mouseleave
+						else {
+							$this.on('mouseleave.tooltipster', function() {
+								object.hideTooltip();
+							});
+						}
 					}
-				});
+					
+					// if click events are set to show and hide the tooltip, attach those events respectively
+					if (object.options.trigger == 'click') {
+						$this.on('click.tooltipster', function() {
+							if (($this.data('tooltipster') === '') || ($this.data('tooltipster') === undefined)) {
+								object.showTooltip();
+							}
+							else {
+								object.hideTooltip();
+							}
+						});
+					}
+				}
 			}
 		},
 		


### PR DESCRIPTION
Hey, I changed the functionInit behavior back to what it was, as in my mind it does not make much sense with the continueInit parameter you gave it. Let me explain more and tell me what you think.

Firstly, I do not think there is a point in allowing to stop the tooltip initialization. If you do not want the tooltip to appear at some point, it is functionBefore's job to achieve that. But if you do not want the tooltip to be initialized, then why would you have tried to initialize it in the first place ?

Secondly, the main purpose of this function is to allow a change on-the-fly from the initial title attribute to the final content you will put in the tooltip. Some people may be happy to have an init callback to do something else, but that is probably not a very common need (still good to have it though).

For example, I never put raw HTML in a title attribute as it is not W3C compliant and presents XSS risks when you do not control the tooltip content. That alone demands that you have an initFunction, to handle things. Anyway in my use case, I more or less change a "Some--stuff" title to a "Some&lt;br />stuff" tooltip.

If you wanted to do this with the functionInit you propose, you would probably go for :

```
functionInit(origin, initContinue){
    var c = origin.tooltipster('val');
    c = sometransformation(c);
    origin.tooltipster('update', c);
    initContinue();
}
```

But that currently does not work. As the widget is not fully initialized (not saved in .data, line 878) when functionInit is executed, you cannot use $(sel).tooltipster('val') on it. You would have to edit the .tooltipster() function for this to work, but I find this overkill, for a not-so-great behavior anyway.

So in the end, I cannot see the point for an initContinue parameter, but I do see the point in being able to change the tooltip content in a very easy way, just by returning something at the end of the function. It's simpler than playing with the val and update methods :

```
functionInit(origin, content){
    return sometransformation(content);
}
```

Thank you !
