### PR TITLE
Fixed icon tooltip (was not working anymore)

### DIFF
--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -909,8 +909,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 							break;
 							
 						case 'elementicon':
+							v = $(this).data('tooltipsterIcon');
+							// we will return the raw HTML element if there is an icon, undefined otherwise
+							v = v ? v[0] : undefined;
 							//return false to stop .each iteration on the first element matched by the selector. No need for a 'break;' after that.
-							v = $(this).data('tooltipsterIcon')[0];
 							return false;
 		
 						case 'update':


### PR DESCRIPTION
Note : this pull request is cumulative to my functionInit pull request, since they affect some of the same lines.

Repaired and improved icon tooltips :
- the tooltip was not working because it tried to take a title element that had already been removed.
- the icon tooltip ignored the content option.
- the icon parameter provided can now be a jquery wrapped object with its bindings, etc (because it is now inserted with .append(), while it was previously inlined)
- suppressed the attachment of the plugin on the icon itself at initialization (line 949), since it is already attached to the original tooltipped element. I see no reason why someone would like to access the widget via $(sel).data('tooltipsterIcon').tooltipster() rather than just $(sel).tooltipster() : it's complicated and opaque.

Unless I have missed something, I think a positioning function is still needed to place the icon at the right spot. For now, they are just inserted in the DOM after the tooltipped element, which must be wrong most of the time, especially if the element has a special position (absolute, floating, etc). Since the positioning of the icon is currently left to the user, at least I added a method to get the HTML element of this icon to work with it : .tooltipster('elementIcon'). As I intend to add .tooltipster('elementTooltip') in a future commit, I thought the name would be consistent.
