### PR TITLE
Added method to get the tooltip element + restructured fn.tooltipster()

### DIFF
--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -131,7 +131,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 				
 				// if this is a touch device, add some touch events to launch the tooltip
 				if ((object.options.touchDevices) && (touchDevice) && ((object.options.trigger == 'click') || (object.options.trigger == 'hover'))) {
-					$this.bind('touchstart', function(element, options) {
+					$this.on('touchstart.tooltipster', function(element, options) {
 						object.showTooltip();
 					});
 				}
@@ -938,7 +938,16 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		
 						case 'destroy':
 							$(this).data('plugin_tooltipster').hideTooltip();
-							$(this).data('plugin_tooltipster', '').attr('title', $t.data('tooltipsterContent')).data('tooltipsterContent', '').data('plugin_tooltipster', '').off('mouseenter.tooltipster mouseleave.tooltipster click.tooltipster').unbind('touchstart');
+							
+							var icon = $(this).data('tooltipsterIcon');
+							if(icon) icon.remove();
+							
+							$(this)
+								.attr('title', $t.data('tooltipsterContent'))
+								.removeData('plugin_tooltipster')
+								.removeData('tooltipsterContent')
+								.removeData('tooltipsterIcon')
+								.off('.tooltipster');
 							break;
 							
 						case 'elementicon':


### PR DESCRIPTION
This pull request is again cumulative with the previous ones... I hope you'll be ok with them.

This commit does two things. It adds an elementTooltip method and it restructures the .tooltipster() function.

Not much to say about the method, it's 4 lines of codes that return the raw HTML element of the tooltip. That will help people like me who want to build interactive tooltip. Basic use case : I want the interactive tooltip to be closed only by clicks outside of it, so I need the element to do my bindings.

About restructuring : it does almost exactly what it did before, but in a more structured manner. It's much commented and now you know exactly what's going on. If more static methods need to be implemented later, now there's a switch for them right there.

The only difference is that your latest modification with the `else` block breaks the code of people who chain method calls on empty sets of objects (when $(sel) does not match anything). I believe this is an undesired behavior and I changed it back to what it was.
