### PR TITLE
Remove the delegated icon in destroy method

### DIFF
--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -130,7 +130,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 					
 					// if this is a touch device, add some touch events to launch the tooltip
 					if ((object.options.touchDevices) && (touchDevice) && ((object.options.trigger == 'click') || (object.options.trigger == 'hover'))) {
-						$this.bind('touchstart', function(element, options) {
+						$this.on('touchstart.tooltipster', function(element, options) {
 							object.showTooltip();
 						});
 					}
@@ -904,8 +904,18 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 							break;
 		
 						case 'destroy':
+							
 							$(this).data('plugin_tooltipster').hideTooltip();
-							$(this).data('plugin_tooltipster', '').attr('title', $t.data('tooltipsterContent')).data('tooltipsterContent', '').data('plugin_tooltipster', '').off('mouseenter.tooltipster mouseleave.tooltipster click.tooltipster').unbind('touchstart');
+							
+							var icon = $(this).data('tooltipsterIcon');
+							if(icon) icon.remove();
+							
+							$(this)
+								.attr('title', $t.data('tooltipsterContent'))
+								.removeData('plugin_tooltipster')
+								.removeData('tooltipsterContent')
+								.removeData('tooltipsterIcon')
+								.off('.tooltipster');
 							break;
 		
 						case 'update':


### PR DESCRIPTION
The delegated icon is now removed in the destroy method + little code cleaning.

REMARK : this commit here is not cumulative to my other pull requests, however I did merge this change on the elementTooltip branch and fixed the resulting conflict at the same time. I suggest you pull my other pull request and disregard this one.
