### PR TITLE
added a quick hack to close dialogs if a click occurs outside the dialog

### DIFF
--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -32,7 +32,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 			iconTheme: '.tooltipster-icon',
 			interactive: false,
 			interactiveTolerance: 350,
-			interactiveAutoClose: true,
+			interactiveAutoClose: true, // only makes sense if trigger is 'click'
 			offsetX: 0,
 			offsetY: 0,
 			onlyOne: true,
@@ -438,6 +438,17 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 									}
 								});
 							}
+							
+							// The following behavior controls closing the dialog if the user clicks outside the dialog
+              $('html').one('click',function() {
+                object.hideTooltip(); // hide the tooltip if the user clicks outside the dialog.
+              });
+							if (object.options.trigger == 'click') {
+                  $('.tooltipster-dialog').click(function(event) {
+                    return false; // don't propogate events that might close the dialog
+                  })
+							}
+							
 						}
 					});
 					


### PR DESCRIPTION
 It's my first hack to close a tooltipster-dialog when a click occurs outside a dialog. I've tested with interactive dialogs where autoClose is false. This should still be tested with interactive hover dialogs before exposing it to the community. 
