### PR TITLE
Added additional option to disable or enable offscreen repositioning of the tooltip

### DIFF
--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -17,6 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 			arrow: true,
 			arrowColor: '',
 			autoClose: true,
+			checkOffScreenY: true,
 			content: null,
 			contentAsHTML: false,
 			contentCloning: true,
@@ -775,15 +776,34 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 				
 				// a function to detect if the tooltip is going off the screen vertically. If so, switch to the opposite!
 				function dontGoOffScreenY(switchTo, switchFrom) {
+
 					// if it goes off the top off the page
 					if(((proxy.offset.top - $(window).scrollTop() - tooltipHeight - offsetY - 12) < 0) && (switchFrom.indexOf('top') > -1)) {
-						practicalPosition = switchTo;
+						switch (self.options.checkOffScreenY)
+							{
+								case true:
+								practicalPosition = switchTo;
+								break;
+
+								case false:
+								practicalPosition = switchFrom;
+								break;
+							}
 					}
 					
 					// if it goes off the bottom of the page
 					if (((proxy.offset.top + proxy.dimension.height + tooltipHeight + 12 + offsetY) > ($(window).scrollTop() + $(window).height())) && (switchFrom.indexOf('bottom') > -1)) {
-						practicalPosition = switchTo;
-						myTop = (proxy.offset.top - tooltipHeight) - offsetY - 12;
+						switch (self.options.checkOffScreenY)
+							{
+								case true:
+								practicalPosition = switchTo;
+								myTop = (proxy.offset.top - tooltipHeight) - offsetY - 12;
+								break;
+
+								case false:
+								practicalPosition = switchFrom;
+								break;
+							}
 					}
 				}
 				


### PR DESCRIPTION
Had a row of images with (relatively large) tooltip content of different heights. The issue was that the "dontGoOffScreenY" function would automatically move bottom positioned content to the top if it didn't fit in the screen (even if barely). I didn't need this function to be on in particular as the tooltip content was large enough for the user to know to scroll down. I couldn't find an option to turn off this automatically enabled function, so I added one.

This is my first public pull request so I would appreciate it if you would let me know if I've done anything stupid. I just wanted to try to contribute something back. 

Thanks for this plugin! It really saved me a ton of time.

Summary:
Added "checkOffScreenY" option with default set to "true"
User may choose to set the option to "false" if he/she wishes to disable the function that repositions offscreen elements (only in the y-direction)
