### PR TITLE
Fixed tooltips not showing in browsers not supporting css animations.

### DIFF
--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -291,7 +291,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 							pointerEvents = self.options.interactive ? 'pointer-events: auto;' : '';
 						
 						// build the base of our tooltip
-						self.$tooltip = $('<div class="tooltipster-base '+ animation +' '+ self.options.theme +'" style="'+ fixedWidth +' '+ maxWidth +' '+ pointerEvents +' '+ animationSpeed +'"><div class="tooltipster-content"></div></div>');
+						self.$tooltip = $('<div class="tooltipster-base '+ self.options.theme +'" style="'+ fixedWidth +' '+ maxWidth +' '+ pointerEvents +' '+ animationSpeed +'"><div class="tooltipster-content"></div></div>');
+						if(supportsTransitions()) {
+                            // only add the animation class if the user has a browser that supports animations
+                            self.$tooltip.addClass(animation);
+                        }
 						
 						// insert the content
 						self.insertContent();


### PR DESCRIPTION
In browsers where css animations is not supported (in this case IE9/IE8) the tooltips does not get shown at all. This seems to be because we're always adding the animation class to the created tooltip element and since the default animation is "fade" we get a tooltip that is caught in a permanent state of

opacity: 0;

I've fixed this by only appending the animation class to the created tooltip element if the browser supports animations. This seems to work properly for me. :)
