### PR TITLE
Fix bug with wrong tooltip offset

### DIFF
--- a/css/tooltipster.css
+++ b/css/tooltipster.css
@@ -44,6 +44,8 @@ html {
 	padding: 0;
 	font-size: 0;
 	line-height: 0;
+  top: 0;
+  left: 0;
 	position: absolute;
 	z-index: 9999999;
 	pointer-events: none;


### PR DESCRIPTION
This commit fixes the bug that is demonstrated on this [video](http://youtu.be/vUj-7neYwuA). The reason the tooltip not positioned correctly:
- On document object hover the tooltip is inserted to DOM.
- Because its `display` property is not set to `none` (but it's still invisible because of `opacity: 0`) it's inserted at the bottom of the page and this block affects page's height.
- Vertical scroll appears and reduces the width of the document.
- Table width is set to 100% that's why its width decreases following the page width.
- Tooltip position calculates taking an account new document width.
- Tooltip is positioned and vertical scroll disappears.
- Page width increases and table's width too.
- The position of tooltip remains the same.
- PROFIT...

Bug on [jsFiddle](http://jsfiddle.net/5Cw4H/15/) and in [full screen](http://jsfiddle.net/5Cw4H/15/show/). To reproduce this bug - open second link and open dev tools in your browser (tested in latest Google Chrome). Then increase dev tools area's height to the maximum but while vertical scrolling does not appear. Try to hover the cursor over the text.

To fix this bug I have just added the initial position of the block to 0,0.
