### PR TITLE
Update jquery.tooltipster.js

### DIFF
--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -774,6 +774,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 				
 					var windowLeft = $(window).scrollLeft();
 					
+					// reset the arrow position
+					self.tooltipArrowReposition = 0;
+					
 					// if the tooltip goes off the left side of the screen, line it up with the left side of the window
 					if((myLeft - windowLeft) < 0) {
 						var arrowReposition = myLeft - windowLeft;


### PR DESCRIPTION
Reset arrow reposition to 0 in case the tooltip is being manually repositioned (calling .tooltipster("reposition")) away from the edge of the screen, leaving the arrow shifted to one side, as if the tooltip was still set flush against the edge, instead of moving the arrow to the center of the tooltip. See below.

![screenhunter_220 jan 22 14 27](https://f.cloud.github.com/assets/2285779/1977710/42ec6cec-839b-11e3-9330-5fe0f4b13d7b.jpg)
![screenhunter_221 jan 22 14 27](https://f.cloud.github.com/assets/2285779/1977709/42e69c22-839b-11e3-825d-ad8b2206ebc2.jpg)
