### PR TITLE
Fix of tooltip freeze when proxy is moving on click

### DIFF
--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -386,14 +386,14 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 									// as for mouse interaction, we get rid of the tooltip only after the mouse has spent some time out of it
 									var tolerance = null;
 
-                  self.$elProxy
-                    // hide after some time out of the proxy
-                    .on('click.'+ self.namespace + '-autoClose', function() {
-                      clearTimeout(tolerance);
-                      tolerance = setTimeout(function(){
-                        self.hide();
-                      }, self.options.interactiveTolerance);
-                    });
+									self.$elProxy
+										// hide after some time out of the proxy
+										.on('click.'+ self.namespace + '-autoClose', function() {
+											clearTimeout(tolerance);
+											tolerance = setTimeout(function(){
+												self.hide();
+											}, self.options.interactiveTolerance);
+										});
 									self.$elProxy.add(self.$tooltip)
 										// hide after some time out of the proxy and the tooltip
 										.on('mouseleave.'+ self.namespace + '-autoClose', function() {
@@ -640,7 +640,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 				self.Status = 'disappearing';
 				
 				var finish = function() {
-					
+
 					self.Status = 'hidden';
 					
 					// detach our content object first, so the next jQuery's remove() call does not unbind its event handlers


### PR DESCRIPTION
This bug only appears in FireFox (tested on latest) and maybe IE.

The bug appears when somebody clicks on proxy and in external place we move this proxy to another place on click event. The tooltip remains on the same place and freezes until we move cursor to proxy again.

The behaviour of native browser's tooltip is to hide it on click. I think that we should do the same. As for now the tooltip does not change it state when we click on proxy.  

See it here: [jsfiddle](http://jsfiddle.net/o8or8knz/6/) (compare Chrome and FF behaviour). When you hover over "Tooltipster" button - the tootipster's tooltip appears. Click on button and it will be moved to container. The tooltip will freeze. When you hover over "Native" button - the native tooltip appears and it hides on click.

My PR may have some mistakes because it's very hard to comprehend all logic of library.
