### PR TITLE
Allow to set the parent container element

### DIFF
--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -57,7 +57,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 			theme: 'tooltipster-default',
 			touchDevices: true,
 			trigger: 'hover',
-			updateAnimation: true
+			updateAnimation: true,
+			container: 'body'
 		};
 	
 	function Plugin(element, options) {
@@ -344,7 +345,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 						self._content_insert();
 						
 						// attach
-						self.$tooltip.appendTo('body');
+						self.$tooltip.appendTo(self.options.container);
 						
 						// do all the crazy calculations and positioning
 						self.reposition();


### PR DESCRIPTION
When testing ember applications using `qunit-fixture` it's really important that generated content (tooltips in this case) be appended to a predefined element. 

We should have a way to tell tooltipster to append the tooltip to a different element than the `body` of the page.

I think it would be a good idea to have a `container` configuration option which allows us to define the parent element of the tooltipster with a default value of `body` (to maintain backwards compatibility). 