### PR TITLE
Docs: Make text in the orange demo circles unselectable

### DIFF
--- a/doc/css/style.css
+++ b/doc/css/style.css
@@ -395,6 +395,11 @@ Demos
 	margin: -1.4em 1em 0 0;
 	text-transform: uppercase;
 	float: left;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	-o-user-select: none;
+	user-select: none;
 }
 #demos span:hover {
 	background: #fff !important;


### PR DESCRIPTION
Click rapidly on the "Custom show / hide triggers" demo circle, and there's a good chance of an annoying text-selection effect.

![screen shot 2015-04-30 at 5 05 01 pm](https://cloud.githubusercontent.com/assets/1156958/7424834/a600ce18-ef5b-11e4-9879-fb14dea3b2e6.png)

This simple PR disables that.