### PR TITLE
Changed distance to be configurable rather than hardcoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ contentAsHTML
 contentCloning  
 debug  
 delay  
+distance  
 minWidth  
 maxWidth  
 functionInit  

--- a/index.html
+++ b/index.html
@@ -312,6 +312,11 @@ $('.tooltip').tooltipster({
 					<td>Delay how long it takes (in milliseconds) for the tooltip to start animating in. <strong>Default: 200</strong></td>
 				</tr>
 				<tr>
+					<td><h4>distance</h4></td>
+					<td>integer</td>
+					<td>Distance between the target element and the tooltip. <strong>Default: 12</strong></td>
+				</tr>
+				<tr>
 					<td><h4>minWidth</h4></td>
 					<td>integer</td>
 					<td>Set a minimum width for the tooltip. <strong>Default: 0 (auto width)</strong></td>

--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -22,6 +22,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 			contentCloning: true,
 			debug: true,
 			delay: 200,
+			distance: 12,
 			minWidth: 0,
 			maxWidth: null,
 			functionInit: function(origin, content) {},
@@ -850,6 +851,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 					myTop = 0,
 					offsetY = parseInt(self.options.offsetY),
 					offsetX = parseInt(self.options.offsetX),
+					distance = parseInt(self.options.distance),
 					// this is the arrow position that will eventually be used. It may differ from the position option if the tooltip cannot be displayed in this position
 					practicalPosition = self.options.position;
 				
@@ -874,35 +876,35 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 				// a function to detect if the tooltip is going off the screen vertically. If so, switch to the opposite!
 				function dontGoOffScreenY(switchTo, switchFrom) {
 					// if it goes off the top off the page
-					if(((proxy.offset.top - $(window).scrollTop() - tooltipHeight - offsetY - 12) < 0) && (switchFrom.indexOf('top') > -1)) {
+					if(((proxy.offset.top - $(window).scrollTop() - tooltipHeight - offsetY - distance) < 0) && (switchFrom.indexOf('top') > -1)) {
 						practicalPosition = switchTo;
 					}
 					
 					// if it goes off the bottom of the page
-					if (((proxy.offset.top + proxy.dimension.height + tooltipHeight + 12 + offsetY) > ($(window).scrollTop() + $(window).height())) && (switchFrom.indexOf('bottom') > -1)) {
+					if (((proxy.offset.top + proxy.dimension.height + tooltipHeight + distance + offsetY) > ($(window).scrollTop() + $(window).height())) && (switchFrom.indexOf('bottom') > -1)) {
 						practicalPosition = switchTo;
-						myTop = (proxy.offset.top - tooltipHeight) - offsetY - 12;
+						myTop = (proxy.offset.top - tooltipHeight) - offsetY - distance;
 					}
 				}
 				
 				if(practicalPosition == 'top') {
 					var leftDifference = (proxy.offset.left + tooltipWidth) - (proxy.offset.left + proxy.dimension.width);
 					myLeft = (proxy.offset.left + offsetX) - (leftDifference / 2);
-					myTop = (proxy.offset.top - tooltipHeight) - offsetY - 12;
+					myTop = (proxy.offset.top - tooltipHeight) - offsetY - distance;
 					dontGoOffScreenX();
 					dontGoOffScreenY('bottom', 'top');
 				}
 				
 				if(practicalPosition == 'top-left') {
 					myLeft = proxy.offset.left + offsetX;
-					myTop = (proxy.offset.top - tooltipHeight) - offsetY - 12;
+					myTop = (proxy.offset.top - tooltipHeight) - offsetY - distance;
 					dontGoOffScreenX();
 					dontGoOffScreenY('bottom-left', 'top-left');
 				}
 				
 				if(practicalPosition == 'top-right') {
 					myLeft = (proxy.offset.left + proxy.dimension.width + offsetX) - tooltipWidth;
-					myTop = (proxy.offset.top - tooltipHeight) - offsetY - 12;
+					myTop = (proxy.offset.top - tooltipHeight) - offsetY - distance;
 					dontGoOffScreenX();
 					dontGoOffScreenY('bottom-right', 'top-right');
 				}
@@ -910,28 +912,28 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 				if(practicalPosition == 'bottom') {
 					var leftDifference = (proxy.offset.left + tooltipWidth) - (proxy.offset.left + proxy.dimension.width);
 					myLeft = proxy.offset.left - (leftDifference / 2) + offsetX;
-					myTop = (proxy.offset.top + proxy.dimension.height) + offsetY + 12;
+					myTop = (proxy.offset.top + proxy.dimension.height) + offsetY + distance;
 					dontGoOffScreenX();
 					dontGoOffScreenY('top', 'bottom');
 				}
 				
 				if(practicalPosition == 'bottom-left') {
 					myLeft = proxy.offset.left + offsetX;
-					myTop = (proxy.offset.top + proxy.dimension.height) + offsetY + 12;
+					myTop = (proxy.offset.top + proxy.dimension.height) + offsetY + distance;
 					dontGoOffScreenX();
 					dontGoOffScreenY('top-left', 'bottom-left');
 				}
 				
 				if(practicalPosition == 'bottom-right') {
 					myLeft = (proxy.offset.left + proxy.dimension.width + offsetX) - tooltipWidth;
-					myTop = (proxy.offset.top + proxy.dimension.height) + offsetY + 12;
+					myTop = (proxy.offset.top + proxy.dimension.height) + offsetY + distance;
 					dontGoOffScreenX();
 					dontGoOffScreenY('top-right', 'bottom-right');
 				}
 				
 				if(practicalPosition == 'left') {
-					myLeft = proxy.offset.left - offsetX - tooltipWidth - 12;
-					myLeftMirror = proxy.offset.left + offsetX + proxy.dimension.width + 12;
+					myLeft = proxy.offset.left - offsetX - tooltipWidth - distance;
+					myLeftMirror = proxy.offset.left + offsetX + proxy.dimension.width + distance;
 					var topDifference = (proxy.offset.top + tooltipHeight) - (proxy.offset.top + proxy.dimension.height);
 					myTop = proxy.offset.top - (topDifference / 2) - offsetY;
 					
@@ -942,21 +944,21 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 						self.$tooltip.css('width', newWidth + 'px');
 						
 						tooltipHeight = self.$tooltip.outerHeight(false);
-						myLeft = proxy.offset.left - offsetX - newWidth - 12 - borderWidth;
+						myLeft = proxy.offset.left - offsetX - newWidth - distance - borderWidth;
 						topDifference = (proxy.offset.top + tooltipHeight) - (proxy.offset.top + proxy.dimension.height);
 						myTop = proxy.offset.top - (topDifference / 2) - offsetY;
 					}
 					
 					// if it only goes off one side, flip it to the other side
 					else if(myLeft < 0) {
-						myLeft = proxy.offset.left + offsetX + proxy.dimension.width + 12;
+						myLeft = proxy.offset.left + offsetX + proxy.dimension.width + distance;
 						arrowReposition = 'left';
 					}
 				}
 				
 				if(practicalPosition == 'right') {
-					myLeft = proxy.offset.left + offsetX + proxy.dimension.width + 12;
-					myLeftMirror = proxy.offset.left - offsetX - tooltipWidth - 12;
+					myLeft = proxy.offset.left + offsetX + proxy.dimension.width + distance;
+					myLeftMirror = proxy.offset.left - offsetX - tooltipWidth - distance;
 					var topDifference = (proxy.offset.top + tooltipHeight) - (proxy.offset.top + proxy.dimension.height);
 					myTop = proxy.offset.top - (topDifference / 2) - offsetY;
 					
@@ -973,7 +975,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 						
 					// if it only goes off one side, flip it to the other side
 					else if((myLeft + tooltipWidth) > windowWidth) {
-						myLeft = proxy.offset.left - offsetX - tooltipWidth - 12;
+						myLeft = proxy.offset.left - offsetX - tooltipWidth - distance;
 						arrowReposition = 'right';
 					}
 				}

--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -851,7 +851,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 					myTop = 0,
 					offsetY = parseInt(self.options.offsetY),
 					offsetX = parseInt(self.options.offsetX),
-					distance = parseInt(self.options.distance),
 					// this is the arrow position that will eventually be used. It may differ from the position option if the tooltip cannot be displayed in this position
 					practicalPosition = self.options.position;
 				


### PR DESCRIPTION
Currently the distance between the target and the tooltip is hardcoded to 12. Changed this to be configurable to have more flexibility in styling e.g. smaller arrows however not looking too far away.