### PR TITLE
tooltip position class

### DIFF
--- a/js/jquery.tooltipster.js
+++ b/js/jquery.tooltipster.js
@@ -1059,6 +1059,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 					var arrowConstruct = '<div class="'+ arrowClass +' tooltipster-arrow" style="'+ arrowReposition +'">'+ arrowBorder +'<span style="border-color:'+ arrowColor +';"></span></div>';
 					self.$tooltip.append(arrowConstruct);
 				}
+				// add class indicating which is the actual position with the tooltip container.
+				self.$tooltip.addClass("tooltipster-" + practicalPosition)
 				
 				// position the tooltip
 				self.$tooltip.css({'top': Math.round(myTop) + 'px', 'left': Math.round(myLeft) + 'px'});


### PR DESCRIPTION
Currently it was not possible to style the container of the tooltip according to the actual position of the tooltip.

Added css class defining the actual position of the tooltip with the tooltip container. This would allow some scenarios of styling (which I needed) e.g. make the border of the tooltip where the arrow is currently to have different color and width.