### PR TITLE
Make bower include only dist files on install

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,5 +4,13 @@
   "main": ["js/jquery.tooltipster.min.js", "css/tooltipster.css"],
   "dependencies": {
     "jquery": ">=1.7"
-  }
+  },
+  "ignore":[
+    "*",
+    "**/**",
+    "!/js/**",
+    "!/css/**",
+    "!/README.*",
+    "!/LICENSE"
+  ]
 }


### PR DESCRIPTION
Don't need the demo or site files when all i want is to include tooltipster as a dependency