### PR TITLE
Unit of measurement is redundant in CSS

### DIFF
--- a/src/css/plugins/tooltipster/sideTip/tooltipster-sideTip.css
+++ b/src/css/plugins/tooltipster/sideTip/tooltipster-sideTip.css
@@ -95,25 +95,25 @@ corresponds to the arrow we want to display */
 
 .tooltipster-sidetip.tooltipster-bottom .tooltipster-arrow-background {
 	border-bottom-color: #565656;
-	left: 0px;
+	left: 0;
 	top: 3px;
 }
 
 .tooltipster-sidetip.tooltipster-left .tooltipster-arrow-background {
 	border-left-color: #565656;
 	left: -3px;
-	top: 0px;
+	top: 0;
 }
 
 .tooltipster-sidetip.tooltipster-right .tooltipster-arrow-background {
 	border-right-color: #565656;
 	left: 3px;
-	top: 0px;
+	top: 0;
 }
 
 .tooltipster-sidetip.tooltipster-top .tooltipster-arrow-background {
 	border-top-color: #565656;
-	left: 0px;
+	left: 0;
 	top: -3px;
 }
 


### PR DESCRIPTION
PhpStorm picked this up while inspecting our codebase.