### PR TITLE
docs: Fix simple typo, namepaces -> namespaces

### DIFF
--- a/dist/js/tooltipster.bundle.js
+++ b/dist/js/tooltipster.bundle.js
@@ -2927,7 +2927,7 @@ $.fn.tooltipster = function() {
 			
 			this.each(function() {
 				
-				// retrieve the namepaces of the tooltip(s) that exist on that element.
+				// retrieve the namespaces of the tooltip(s) that exist on that element.
 				// We will interact with the first tooltip only.
 				var ns = $(this).data('tooltipster-ns'),
 					// self represents the instance of the first tooltipster plugin

--- a/dist/js/tooltipster.main.js
+++ b/dist/js/tooltipster.main.js
@@ -2927,7 +2927,7 @@ $.fn.tooltipster = function() {
 			
 			this.each(function() {
 				
-				// retrieve the namepaces of the tooltip(s) that exist on that element.
+				// retrieve the namespaces of the tooltip(s) that exist on that element.
 				// We will interact with the first tooltip only.
 				var ns = $(this).data('tooltipster-ns'),
 					// self represents the instance of the first tooltipster plugin

--- a/src/js/tooltipster.js
+++ b/src/js/tooltipster.js
@@ -2905,7 +2905,7 @@ $.fn.tooltipster = function() {
 			
 			this.each(function() {
 				
-				// retrieve the namepaces of the tooltip(s) that exist on that element.
+				// retrieve the namespaces of the tooltip(s) that exist on that element.
 				// We will interact with the first tooltip only.
 				var ns = $(this).data('tooltipster-ns'),
 					// self represents the instance of the first tooltipster plugin


### PR DESCRIPTION
There is a small typo in dist/js/tooltipster.bundle.js, dist/js/tooltipster.main.js, src/js/tooltipster.js.

Should read `namespaces` rather than `namepaces`.

